### PR TITLE
add dlscorldnews.com

### DIFF
--- a/domains.list
+++ b/domains.list
@@ -1003,3 +1003,4 @@ ytspacex.com
 yyoutube.com
 zief.pl
 zoudlogick.net
+dlscorldnews.com


### PR DESCRIPTION
- [x] Added a new domain (`dlscorldnews.com`)

The scam in itself is being ran at `https://dlscorldnews.com/alis`.